### PR TITLE
Move env var declarations to top level, refactor SupplyClient

### DIFF
--- a/SupplyQueryDemo/SupplyQueryDemo/Program.cs
+++ b/SupplyQueryDemo/SupplyQueryDemo/Program.cs
@@ -15,7 +15,11 @@ query Search($mpn: String!) {
   }
 }";
 
-using HttpClient supplyClient = SupplyClient.CreateClient();
+// assume Nexar client ID and secret are set as environment variables
+string clientId = Environment.GetEnvironmentVariable("NEXAR_CLIENT_ID") ?? throw new InvalidOperationException("Please set environment variable 'NEXAR_CLIENT_ID'");
+string clientSecret = Environment.GetEnvironmentVariable("NEXAR_CLIENT_SECRET") ?? throw new InvalidOperationException("Please set environment variable 'NEXAR_CLIENT_SECRET'");
+
+using SupplyClient supplyClient = new(clientId, clientSecret);
 
 while (true)
 {
@@ -24,9 +28,6 @@ while (true)
     var mpn = Console.ReadLine();
     if (string.IsNullOrEmpty(mpn))
         return;
-
-    // populate or replace the supply token
-    await supplyClient.PopulateTokenAsync();
 
     // run the query
     Request request = new()

--- a/SupplyQueryDemo/SupplyQueryDemo/SupplyClient.cs
+++ b/SupplyQueryDemo/SupplyQueryDemo/SupplyClient.cs
@@ -16,14 +16,14 @@ namespace SupplyQueryDemo
 
         private readonly string clientId;
         private readonly string clientSecret;
-        private readonly HttpClient innerClient;
+        private readonly HttpClient httpClient;
 
         public SupplyClient(string clientId, string clientSecret)
         {
             this.clientId = clientId;
             this.clientSecret = clientSecret;
 
-            innerClient = new HttpClient()
+            httpClient = new HttpClient()
             {
                 BaseAddress = new Uri("https://api.nexar.com/graphql")
             };
@@ -35,7 +35,7 @@ namespace SupplyQueryDemo
             // https://github.com/NexarDeveloper/nexar-templates/tree/main/nexar-console-supply
             await EnsureValidTokenAsync();
             string requestString = JsonConvert.SerializeObject(request);
-            HttpResponseMessage httResponse = await innerClient.PostAsync(innerClient.BaseAddress, new StringContent(requestString, Encoding.UTF8, "application/json"));
+            HttpResponseMessage httResponse = await httpClient.PostAsync(httpClient.BaseAddress, new StringContent(requestString, Encoding.UTF8, "application/json"));
             httResponse.EnsureSuccessStatusCode();
             string responseString = await httResponse.Content.ReadAsStringAsync();
             Response response = JsonConvert.DeserializeObject<Response>(responseString);
@@ -53,12 +53,12 @@ namespace SupplyQueryDemo
             }
 
             // set the default Authorization header so it includes the token
-            innerClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
 
         public void Dispose()
         {
-            innerClient.Dispose();
+            httpClient.Dispose();
         }
     }
 }

--- a/SupplyQueryDemo/SupplyQueryDemo/SupplyClient.cs
+++ b/SupplyQueryDemo/SupplyQueryDemo/SupplyClient.cs
@@ -5,31 +5,44 @@ using System.Text;
 
 namespace SupplyQueryDemo
 {
-    internal static class SupplyClient
+    internal class SupplyClient : IDisposable
     {
         // access tokens expire after one day
         private static readonly TimeSpan tokenLifetime = TimeSpan.FromDays(1);
-
-        // assume Nexar client ID and secret are set as environment variables
-        private static readonly string clientId = Environment.GetEnvironmentVariable("NEXAR_CLIENT_ID") ?? throw new InvalidOperationException("Please set environment variable 'NEXAR_CLIENT_ID'");
-        private static readonly string clientSecret = Environment.GetEnvironmentVariable("NEXAR_CLIENT_SECRET") ?? throw new InvalidOperationException("Please set environment variable 'NEXAR_CLIENT_SECRET'");
 
         // keep track of token and expiry time
         private static string? token = null;
         private static DateTime tokenExpiresAt = DateTime.MinValue;
 
-        internal static HttpClient CreateClient()
+        private readonly string clientId;
+        private readonly string clientSecret;
+        private readonly HttpClient innerClient;
+
+        public SupplyClient(string clientId, string clientSecret)
         {
-            // create and configure the supply client
-            HttpClient supplyClient = new()
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+
+            innerClient = new HttpClient()
             {
                 BaseAddress = new Uri("https://api.nexar.com/graphql")
             };
-
-            return supplyClient;
         }
 
-        internal static async Task PopulateTokenAsync(this HttpClient supplyClient)
+        public async Task<Response> RunQueryAsync(Request request)
+        {
+            // for another way of running GraphQL queries, see the related demo at:
+            // https://github.com/NexarDeveloper/nexar-templates/tree/main/nexar-console-supply
+            await EnsureValidTokenAsync();
+            string requestString = JsonConvert.SerializeObject(request);
+            HttpResponseMessage httResponse = await innerClient.PostAsync(innerClient.BaseAddress, new StringContent(requestString, Encoding.UTF8, "application/json"));
+            httResponse.EnsureSuccessStatusCode();
+            string responseString = await httResponse.Content.ReadAsStringAsync();
+            Response response = JsonConvert.DeserializeObject<Response>(responseString);
+            return response;
+        }
+
+        private async Task EnsureValidTokenAsync()
         {
             // get an access token, replacing the existing one if it has expired
             if (token == null || DateTime.UtcNow >= tokenExpiresAt)
@@ -40,19 +53,12 @@ namespace SupplyQueryDemo
             }
 
             // set the default Authorization header so it includes the token
-            supplyClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            innerClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
 
-        internal static async Task<Response> RunQueryAsync(this HttpClient supplyClient, Request request)
+        public void Dispose()
         {
-            // for another way of running GraphQL queries, see the related demo at:
-            // https://github.com/NexarDeveloper/nexar-templates/tree/main/nexar-console-supply
-            string requestString = JsonConvert.SerializeObject(request);
-            HttpResponseMessage httResponse = await supplyClient.PostAsync(supplyClient.BaseAddress, new StringContent(requestString, Encoding.UTF8, "application/json"));
-            httResponse.EnsureSuccessStatusCode();
-            string responseString = await httResponse.Content.ReadAsStringAsync();
-            Response response = JsonConvert.DeserializeObject<Response>(responseString);
-            return response;
+            innerClient.Dispose();
         }
     }
 }


### PR DESCRIPTION
Moved the environment variable declarations as discussed.

I also figured that SupplyClient might be useful as a non-static wrapper for HttpClient which checks automatically whether the access token has expired before sending a GraphQL query.