### PR TITLE
Extract lifecycle status in python demo

### DIFF
--- a/python/SupplyQueryDemo/program.py
+++ b/python/SupplyQueryDemo/program.py
@@ -12,11 +12,24 @@ query Search($mpn: String!) {
           manufacturer {
             name
           }
+          specs {
+            attribute {
+              shortname
+            }
+            value
+          }
         }
       }
     }
   }
 '''
+
+def getLifecycleStatus(specs):
+    if specs:
+        lifecycleSpec = [i for (i) in specs if i.get('attribute',{}).get('shortname') == 'lifecyclestatus']
+        if len(lifecycleSpec) > 0:
+            return lifecycleSpec[0].get('value',{})
+    return ''
 
 if __name__ == '__main__':
 
@@ -40,6 +53,7 @@ if __name__ == '__main__':
                 print(f'MPN: {it.get("part",{}).get("mpn")}')
                 print(f'Description: {it.get("part",{}).get("shortDescription")}')
                 print(f'Manufacturer: {it.get("part",{}).get("manufacturer",{}).get("name")}')
+                print(f'Lifecycle Status: {getLifecycleStatus(it.get("part",{}).get("specs",{}))}')
                 print()
         else:
             print('Sorry, no parts found')

--- a/python/SupplyQueryDemo/requirements.txt
+++ b/python/SupplyQueryDemo/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
We've had a request for how to extract lifecycle status programmatically from the `specs` attribute.  The way specs are set-up in the schema makes this a little non-trivial.  This PR adds to the python example how to seek and then manipulate the specs array to extract this information as well as the existing information (MPN, description, manufacturer name).

What I especially like about this change is it immediately shows more of the power of the Nexar API to users on their very first hand-rolled query.  Note that self-serve customers will need to have `tech specs` and `lifecycle` features enabled or use a second exploratory app.  Those still on the Welcome 1K plan and enterprise customers will not be impacted.